### PR TITLE
use airbnb-linter settings to self enforce JavaScript guidelines

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,8 +35,66 @@ module.exports = function(grunt) {
         /* JSHint - Check JS syntax */
         jshint: {
             options: {
-                loopfunc: true,
-                expr: true
+                /*
+                 * ENVIRONMENTS
+                 * =================
+                 */
+                
+                // Define globals exposed by modern browsers.
+                "browser": true,
+                
+                // Define globals exposed by jQuery.
+                "jquery": true,
+                
+                // Define globals exposed by Node.js.
+                "node": true,
+                
+                // Allow ES6.
+                "esnext": true,
+                
+                /*
+                 * ENFORCING OPTIONS
+                 * =================
+                 */
+                
+                // Force all variable names to use either camelCase style or UPPER_CASE
+                // with underscores.
+                "camelcase": true,
+                
+                // Prohibit use of == and != in favor of === and !==.
+                "eqeqeq": true,
+                
+                // Enforce tab width of 2 spaces.
+                "indent": 2,
+                
+                // Prohibit use of a variable before it is defined.
+                "latedef": true,
+                
+                // Enforce line length to 80 characters
+                "maxlen": 80,
+                
+                // Require capitalized names for constructor functions.
+                "newcap": true,
+                
+                // Enforce use of single quotation marks for strings.
+                "quotmark": "single",
+                
+                // Enforce placing 'use strict' at the top function scope
+                "strict": true,
+                
+                // Prohibit use of explicitly undeclared variables.
+                "undef": true,
+                
+                // Warn when variables are defined but never used.
+                "unused": true,
+                
+                /*
+                 * RELAXING OPTIONS
+                 * =================
+                 */
+                
+                // Suppress warnings about == null comparisons.
+                "eqnull": true
             },
             scripts: ['src/js/**/*.js', '!src/js/vendor/**/*'],
         },


### PR DESCRIPTION
In the documentation we say that we want to use the [AirBnB JavaScript guide](https://github.com/airbnb/javascript/).  This PR adds the necessary linter settings to the grunt file.

I haven't fixed the output of `grunt jshint`

    >> 146 errors in 24 files
    Warning: Task "jshint:scripts" failed. Use --force to continue

    Aborted due to warnings.

This brings up many more interesting questions with respect to JavaScript.

What version of JavaScript do we support?  AirBNB have now changed to go for ES6 by default, and technologies like [BabelJS](https://bablejs.io) potentially allow us to make that choice too, dependent on what browsers we want to support.