### PR TITLE
adding max width to lightbox to prevent overflowing thumbnails

### DIFF
--- a/src/lightbox/css/components/_honeycomb.lightbox.components.lightbox.scss
+++ b/src/lightbox/css/components/_honeycomb.lightbox.components.lightbox.scss
@@ -9,6 +9,7 @@
 .lightbox {
     position: relative;
     display: inline-block;
+    max-width: 100%;
 
     // IE7 support.
     .ie7 & {


### PR DESCRIPTION
fixes thumbnails overflowing in firefox, e.g. www.red-gate.com/products/sql-development/sql-search/ 