### PR TITLE
Removed margins from .band .notification-block

### DIFF
--- a/src/notification/css/components/_honeycomb.notification.block.scss
+++ b/src/notification/css/components/_honeycomb.notification.block.scss
@@ -1,8 +1,3 @@
-.band .notification--block {
-    @include margin(0.5, left);
-    @include margin(0.5, right);
-}
-
 .notification--block {
 
     border: none;


### PR DESCRIPTION
I don't think we should be including margins on notifications that have
band as a parent element. They're block-level so should take up a
full-width. Also, this rule is too specific to be overridden by any of
the 'spaced' classes . . .