### PR TITLE
Fix "unclosed parenthesis in media query expression"

### DIFF
--- a/src/base/css/mixins/_honeycomb.base.mixins.responsive.scss
+++ b/src/base/css/mixins/_honeycomb.base.mixins.responsive.scss
@@ -7,7 +7,8 @@
   @if map-has-key($breakpoints, $breakpoint) {
 
     $width: map-get($breakpoints, $breakpoint);
-    @media only screen and (#{$mqProperty} $width) {
+    $declaration: "(#{$mqProperty} #{$width})";
+    @media only screen and #{$declaration} {
       @content;
     }
 


### PR DESCRIPTION
By being consistent with how we do things elsewhere