### PR TITLE
Confluence 'Expand' macro bug fix.

### DIFF
--- a/src/confluence/css/objects/_honeycomb.confluence.objects.expand.scss
+++ b/src/confluence/css/objects/_honeycomb.confluence.objects.expand.scss
@@ -8,7 +8,7 @@
         }
     }
 
-    .expand-control-icon {
+    .expand-icon {
         display: none;
     }
 
@@ -22,10 +22,10 @@
         }
 
         &:before {
-            @include margin(0, 'right', true);
+            @include margin(0.1, 'right', true);
         }
 
-        &.expand-hidden {
+        &.expand-content-hidden {
             @extend .icon--chevron-right;
         }
     }

--- a/src/confluence/js/honeycomb.confluence.expand.js
+++ b/src/confluence/js/honeycomb.confluence.expand.js
@@ -1,6 +1,7 @@
 const classNames = {
     hidden: 'expand-hidden',
-    revealed: 'expand-revealed'
+    revealed: 'expand-revealed',
+    contentHidden: 'expand-content-hidden',
 };
 
 let containers = null;
@@ -34,9 +35,9 @@ const addHandler = ( control, content ) => {
 
 const updateControl = ( control, content ) => {
     if (content.classList.contains(classNames.hidden)) {
-        control.classList.add(classNames.hidden);
+        control.classList.add(classNames.contentHidden);
     } else {
-        control.classList.remove(classNames.hidden);
+        control.classList.remove(classNames.contentHidden);
     }
 };
 


### PR DESCRIPTION
`.expand-hidden` now hides any elements attached, so need a new class to hook from.