### PR TITLE
add a method to set a Google Optimize container ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-web-toolkit",
-  "version": "10.17.0",
+  "version": "10.17.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/red-gate/honeycomb-web-toolkit"

--- a/src/analytics/js/honeycomb.analytics.google.js
+++ b/src/analytics/js/honeycomb.analytics.google.js
@@ -1,5 +1,6 @@
 let accountId;
 let sites;
+let optimizeContainerId;
 
 let init = ( s = false ) => {
 
@@ -35,6 +36,10 @@ let setSites = ( s ) => {
     sites = s;
 };
 
+let setOptimizeId = ( id ) => {
+    optimizeContainerId = id;
+};
+
 // Add the Google Analytics script to the page.
 // Expanded out the isogram iife.
 let addScript = () => {
@@ -60,6 +65,11 @@ let initAccount = ( accountId ) => {
 
     if ( sites ) {
         window.ga( 'create', accountId, 'auto', { 'allowLinker': true } );
+
+        if ( optimizeContainerId ) {
+            window.ga('require', optimizeContainerId);
+        }
+
         window.ga( 'require', 'linker' );
         window.ga( 'linker:autoLink', sites );
     } else {
@@ -132,6 +142,7 @@ export default {
     init,
     setAccountId,
     setSites,
+    setOptimizeId,
     trackPageView,
     trackEvent,
     setCustomVariable,

--- a/src/analytics/js/honeycomb.analytics.google.js
+++ b/src/analytics/js/honeycomb.analytics.google.js
@@ -65,15 +65,14 @@ let initAccount = ( accountId ) => {
 
     if ( sites ) {
         window.ga( 'create', accountId, 'auto', { 'allowLinker': true } );
-
-        if ( optimizeContainerId ) {
-            window.ga('require', optimizeContainerId);
-        }
-
         window.ga( 'require', 'linker' );
         window.ga( 'linker:autoLink', sites );
     } else {
         window.ga( 'create', accountId, 'auto' );
+    }
+
+    if ( optimizeContainerId ) {
+        window.ga('require', optimizeContainerId);
     }
 };
 


### PR DESCRIPTION
https://support.google.com/optimize/answer/6262084

There's conflicting advice on where to put the `require` statement, but I've gone for where they show it in the code (after the `create`), rather than where they say in the text (before the `create`), to group it with the other `require` statement 