### PR TITLE
extend .video-container styles to .js-video-container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-web-toolkit",
-  "version": "10.17.13",
+  "version": "10.17.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/red-gate/honeycomb-web-toolkit"

--- a/src/video/css/objects/_honeycomb.video.objects.video.scss
+++ b/src/video/css/objects/_honeycomb.video.objects.video.scss
@@ -1,3 +1,4 @@
+.js-video-container, 
 .video-container {
     position: relative;
     padding-bottom: 56.25%; /* 16:9 ratio */
@@ -5,7 +6,10 @@
     overflow: hidden;
 }
 
-.video-container iframe, iframe.video, iframe.js-background-video__video {
+.js-video-container iframe,
+.video-container iframe, 
+iframe.video, 
+iframe.js-background-video__video {
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
To fix layout bugs where a container with the .js-video-container class can e.g. overflow its container, because the .video-container styles aren't being applied