### PR TITLE
Add error logging for Marketo forms javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-web-toolkit",
-  "version": "10.17.14",
+  "version": "10.17.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/red-gate/honeycomb-web-toolkit"

--- a/src/document/js/honeycomb.document.load-script.js
+++ b/src/document/js/honeycomb.document.load-script.js
@@ -1,4 +1,4 @@
-const load = ( url = false, callback = false, attrs = {} ) => {
+const load = ( url = false, callback = false, attrs = {}, errorCallback = false ) => {
     if ( url !== false ) {
         let se = document.createElement( 'script' );
         const honeycombPath = (window.Honeycomb && window.Honeycomb.path) ? window.Honeycomb.path : '';
@@ -17,6 +17,10 @@ const load = ( url = false, callback = false, attrs = {} ) => {
                 }
             }
         };
+
+        if ( typeof errorCallback === 'function' ) {
+            se.onerror = errorCallback;
+        }
 
         // Custom attributes.
         for ( let prop in attrs ) {

--- a/src/forms/js/honeycomb.forms.marketo.js
+++ b/src/forms/js/honeycomb.forms.marketo.js
@@ -1,4 +1,5 @@
 import loadScript from '../../document/js/honeycomb.document.load-script';
+import { trackEvent } from '../../analytics/js/honeycomb.analytics.google';
 
 /**
  * The default form settings.
@@ -78,6 +79,18 @@ const hasCustomSuccess = config => {
     }
 
     return customSuccess;
+};
+
+
+/**
+ * Error logging if the script fails to load 
+ * 
+ * Sends an event to Google Analytics
+ */
+const handleError = () => {
+    if ( typeof trackEvent !== 'function' ) return false;
+
+    trackEvent( 'Marketo', 'Marketo forms javascript failed to load', window.location.path );
 };
 
 /*
@@ -197,7 +210,7 @@ const create = c => {
                 });
             }
         );
-    });
+    }, {}, handleError);
 };
 
 const init = callback => {


### PR DESCRIPTION
- add an argument to loadScript to take an `onerror` handler
- add an error logger to the script loader for Marketo forms
