### PR TITLE
Email validation fix

### DIFF
--- a/src/forms/js/honeycomb.forms.marketo.js
+++ b/src/forms/js/honeycomb.forms.marketo.js
@@ -179,9 +179,9 @@ const create = c => {
                         // Email validation.
                         if (typeof fields.Email !== 'undefined') {
 
-                            // Email regex provided by https://regex101.com/r/L9Z2N0/1.
-                            // Check that the format is {something}@{something}.{something}.
-                            const emailRegex = /\S+@\S+\.\S+/;
+                            // Email regex provided by https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/using_regular_expressions_to_validate_email_addresses.htm.
+                            // Check that the format is acceptable to Salesforce (only valid salesforce characters, single @, at least one . character in domain).
+                            const emailRegex = "^[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$" ;
 
                             if (emailRegex.test(fields.Email) === false) {
                                 fail.isFail = true;

--- a/src/forms/js/honeycomb.forms.marketo.js
+++ b/src/forms/js/honeycomb.forms.marketo.js
@@ -181,7 +181,7 @@ const create = c => {
 
                             // Email regex provided by https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/using_regular_expressions_to_validate_email_addresses.htm.
                             // Check that the format is acceptable to Salesforce (only valid salesforce characters, single @, at least one . character in domain).
-                            const emailRegex = '^[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$' ;
+                            const emailRegex = RegExp('^[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$') ;
 
                             if (emailRegex.test(fields.Email) === false) {
                                 fail.isFail = true;

--- a/src/forms/js/honeycomb.forms.marketo.js
+++ b/src/forms/js/honeycomb.forms.marketo.js
@@ -183,7 +183,7 @@ const create = c => {
                             // Check that the format is acceptable to Salesforce (only valid salesforce characters, single @, at least one . character in domain).
                             const emailRegex = RegExp('^[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$') ;
 
-                            if (emailRegex.test(fields.Email) === false) {
+                            if (emailRegex.test(fields.Email.toLowerCase()) === false) {
                                 fail.isFail = true;
                                 fail.message = 'Please enter a valid email address.';
                                 fail.element = marketoForm.getFormElem().find('input[name="Email"]');

--- a/src/forms/js/honeycomb.forms.marketo.js
+++ b/src/forms/js/honeycomb.forms.marketo.js
@@ -181,7 +181,7 @@ const create = c => {
 
                             // Email regex provided by https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/using_regular_expressions_to_validate_email_addresses.htm.
                             // Check that the format is acceptable to Salesforce (only valid salesforce characters, single @, at least one . character in domain).
-                            const emailRegex = "^[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$" ;
+                            const emailRegex = '^[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$' ;
 
                             if (emailRegex.test(fields.Email) === false) {
                                 fail.isFail = true;


### PR DESCRIPTION
This is additional validation using Salesforce's own regex to match their email rules: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/using_regular_expressions_to_validate_email_addresses.htm

I've tested this with quite a few email addresses and the main issue I can see is that it flatly rejects emails with uppercase characters. Since email addresses should be (largely) case-insensitive this feels like overkill.

We could:

- Run with it (maybe expand the error message?) since there's some value to it
- Just pass through a lowercase version of whatever's typed into the test
- Strip that validation out of the regex (feels like there's probably value in matching SFDC exactly for maintainability)

What do people think?