### PR TITLE
Marketo form scroll to error

### DIFF
--- a/src/forms/js/honeycomb.forms.marketo.js
+++ b/src/forms/js/honeycomb.forms.marketo.js
@@ -199,8 +199,14 @@ const create = c => {
                             // Show an error message against the invalid field.
                             marketoForm.showErrorMessage(fail.message, fail.element);
 
-                            // Display the field as invalid using the Marketo class.
+                            // Display the field as invalid using the Marketo class and scroll to the highest erroring field.
                             fail.element.get(0).classList.add('mktoInvalid');
+
+                            const invalidSection = getElementsByClass('mktoInvalid');
+                            if (invalidSection) {
+                                invalidSection.scrollIntoView();
+                            } 
+                            
                         } else {
 
                             // All is good, continue as normal.

--- a/src/forms/js/honeycomb.forms.marketo.js
+++ b/src/forms/js/honeycomb.forms.marketo.js
@@ -199,13 +199,12 @@ const create = c => {
                             // Show an error message against the invalid field.
                             marketoForm.showErrorMessage(fail.message, fail.element);
 
-                            // Display the field as invalid using the Marketo class and scroll to the highest erroring field.
-                            fail.element.get(0).classList.add('mktoInvalid');
+                            //Scroll to the highest erroring field.
+                            const invalidSection = fail.element.get(0).previousSibling;
+                            invalidSection.scrollIntoView(true);
 
-                            const invalidSection = getElementsByClass('mktoInvalid');
-                            if (invalidSection) {
-                                invalidSection.scrollIntoView();
-                            } 
+                            // Display the field as invalid using the Marketo class.
+                            fail.element.get(0).classList.add('mktoInvalid');
                             
                         } else {
 

--- a/src/forms/js/honeycomb.forms.marketo.js
+++ b/src/forms/js/honeycomb.forms.marketo.js
@@ -201,7 +201,7 @@ const create = c => {
 
                             //Scroll to the highest erroring field.
                             const invalidSection = fail.element.get(0).previousSibling;
-                            invalidSection.scrollIntoView(true);
+                            invalidSection.scrollIntoView({ block: 'center' });
 
                             // Display the field as invalid using the Marketo class.
                             fail.element.get(0).classList.add('mktoInvalid');


### PR DESCRIPTION
Per https://github.com/red-gate/website-static/pull/1516, this adds scroll to (the highest available) error on submission. I've made this a jump rather than a smooth scroll because I have a feeling that's going to be less annoying when trying to submit a form.