### PR TITLE
tab navigation update for dropdown anchors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-web-toolkit",
-  "version": "11.0.3",
+  "version": "11.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/red-gate/honeycomb-web-toolkit"

--- a/src/navigation/js/honeycomb.navigation.dropdown.js
+++ b/src/navigation/js/honeycomb.navigation.dropdown.js
@@ -20,7 +20,10 @@ let addArrows = () => {
         if ( $this.hasClass(classNameNoArrow) ) return;
         
         if ( ( $this.find( 'ul' ).length > 0 ) && ( $this.attr( 'data-arrow-added' ) !== 'true' ) ) {
-            let $a = window.jQuery( '<a/>' ).attr( 'href', '#toggle' ).addClass( 'arrow' );
+            let $a = window.jQuery( '<a/>' )
+                .attr( 'href', '#toggle' )
+                .attr( 'tabindex', '-1' ) // Remove the dropdown arrow from the tab index, as it just duplicates the original anchor
+                .addClass( 'arrow' );
             $this.addClass( `dropdown ${classNameClosed}` );
             $this.attr( 'data-arrow-added', 'true' );
             $a.appendTo( $this );


### PR DESCRIPTION
Remove the dynamically added toggle element (the dropdown arrow) from the tab index, as it's a duplicate of the original anchor

This was one of the recommendations from the accessibility assessment on the SQL Monitor product page
