### PR TITLE
SASS: Replace @elseif with @else if

### DIFF
--- a/src/type/css/mixins/_honeycomb.type.mixins.font-size.scss
+++ b/src/type/css/mixins/_honeycomb.type.mixins.font-size.scss
@@ -13,7 +13,7 @@
   } @else {
     @if (type-of($line-height) == number or $line-height == inherit or $line-height == normal) {
       line-height: $line-height;
-    } @elseif ($line-height != none and $line-height != false) {
+    } @else if ($line-height != none and $line-height != false) {
       @warn "‘#{$line-height}’ is not a valid value for `line-height`.";
     }
   }


### PR DESCRIPTION
SASS: Replace `@elseif` with `@else if`

To fix the warning:
>       DEPRECATION WARNING on line 16, column 7 of node_modules\honeycomb-web-toolkit\src\type\css\mixins\_honeycomb.type.mixins.font-size.scss:
>       @elseif is deprecated and will not be supported in future Sass versions.
>       Use "@else if" instead.