### PR TITLE
Raise z-index of header

### DIFF
--- a/src/navigation/css/components/_honeycomb.navigation.components.header.scss
+++ b/src/navigation/css/components/_honeycomb.navigation.components.header.scss
@@ -1,7 +1,7 @@
 .header--primary {
     position: relative;
     overflow: visible;
-    z-index: 30;
+    z-index: 1001;
     height: $hc-navigation-minimum-height !important;
     transition: $hc-navigation-transition;
 


### PR DESCRIPTION
Raising the parent element of the buy button dropdown so that it can display above the sticky nav.