### PR TITLE
add aliases for other Flyway editions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-web-toolkit",
-  "version": "13.1.1",
+  "version": "13.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/red-gate/honeycomb-web-toolkit"

--- a/src/icons/css/objects/_honeycomb.icons.objects.product-icons.scss
+++ b/src/icons/css/objects/_honeycomb.icons.objects.product-icons.scss
@@ -228,7 +228,9 @@
 }
 
 .icon--flyway,
-.icon--flyway-desktop {
+.icon--flyway-desktop,
+.icon--flyway-teams,
+.icon--flyway-enterprise {
     @extend %icon;
     &:before, &:after {
         content: "\e968";


### PR DESCRIPTION
To help Handlebars pull through the right icons when using the Wordpress product data