### PR TITLE
Disable font synthesis

### DIFF
--- a/src/icons/css/objects/_honeycomb.icons.objects.icons.scss
+++ b/src/icons/css/objects/_honeycomb.icons.objects.icons.scss
@@ -50,6 +50,7 @@
     &:before, &:after {
         font-family: "Redgate";
         font-size: $hc-icon-font-size;
+        font-synthesis: none;
         vertical-align: $hc-icon-vertical-alignment;
     }
 


### PR DESCRIPTION
Some browsers will try to synthesize bold variants for fonts that don't have a bold variant. They'll try to do this for the icon font with a result that's almost always terrible.

![image](https://user-images.githubusercontent.com/22743968/193248294-0f1b1053-8376-436d-aa18-4d0103c54afc.png)

Disable by using `font-synthesis: none;`