### PR TITLE
When using .text--normal in combination with heading classes, keep the default font color instead of setting it to the heading color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-web-toolkit",
-  "version": "14.2.6",
+  "version": "14.2.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/red-gate/honeycomb-web-toolkit"

--- a/src/type/css/trumps/_honeycomb.type.trumps.text.scss
+++ b/src/type/css/trumps/_honeycomb.type.trumps.text.scss
@@ -68,6 +68,14 @@
 
 .text--normal {
   font-weight: normal !important;
+
+  &.alpha,
+  &.beta,
+  &.gamma,
+  &.delta,
+  &.zeta {
+    color: inherit;
+  }
 }
 
 


### PR DESCRIPTION
A slightly hacky fix, but think this will be the most straightforward way to handle it. I expect the real fix is we should move away from this class pattern in future, as we're using heading classes to adjust text size, then selectively undoing some of the side effects, but not all. We probably want to introduce classes just for font-size + line-height. 

for https://redgate.monday.com/boards/1408050996/pulses/5523967193