### PR TITLE
Add overflow clip to .band

### DIFF
--- a/src/base/css/objects/_honeycomb.base.objects.band.scss
+++ b/src/base/css/objects/_honeycomb.base.objects.band.scss
@@ -11,6 +11,7 @@
   position: relative;
   width: 100%;
   overflow: hidden;
+  overflow: clip; /* Enables child sticky elements if supported */
   clear: both;
 }
 


### PR DESCRIPTION
This should let us use sticky inside .band elements. The actual sticky code will be in redgate.confluence.css.