### PR TITLE
Resolve honeycomb button styling conflict

### DIFF
--- a/src/button/css/raw/_honeycomb.button.raw.buttons.scss
+++ b/src/button/css/raw/_honeycomb.button.raw.buttons.scss
@@ -1,4 +1,4 @@
-input[type="submit"], button {
+input[type="submit"], button:not(.aui-button) {
     @extend %button;
     
     &.button--large {


### PR DESCRIPTION
This PR should solve this ticket: [https://rgcoreservices.zendesk.com/agent/tickets/118480](https://rgcoreservices.zendesk.com/agent/tickets/118480)

I've copied the built CSS into the theme and it's corrected the styling:
[https://documentation.red-gate.com/fd/supported-databases-and-versions-143754067.html](https://documentation.red-gate.com/fd/supported-databases-and-versions-143754067.html)