### PR TITLE
move the Google reCaptcha privacy notice into our privacy notice block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-web-toolkit",
-  "version": "14.3.12",
+  "version": "14.3.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/red-gate/honeycomb-web-toolkit"

--- a/src/forms/js/honeycomb.forms.marketo.js
+++ b/src/forms/js/honeycomb.forms.marketo.js
@@ -135,6 +135,21 @@ const formatCheckboxes = form => {
     }
 };
 
+/**
+ * Move the Google reCaptcha privacy notice into our privacy notice block.
+ * Currently this notice only shows up on selected forms.
+ * 
+ * @param {HTMLElement} form The Marketo form
+ */
+const formatReCaptchaPrivacyNotice = form => {
+    const reCaptchaPrivacyNotice = form.querySelector('.mktoCaptchaDisclaimer');
+    const privacyNoticeBlock = form.querySelector('.mktoPrivacyNotice div');
+
+    if ( ! reCaptchaPrivacyNotice || ! privacyNoticeBlock ) return;
+
+    privacyNoticeBlock.appendChild(reCaptchaPrivacyNotice);
+};
+
 const create = c => {
     
     // Get the config for the form.
@@ -158,6 +173,7 @@ const create = c => {
 
                 removeDefaultStyles();
                 formatCheckboxes(marketoFormElement);
+                formatReCaptchaPrivacyNotice();
 
                 // Replicate default Google Analytics `form_submit` event.
                 marketoForm.onSuccess(() => {


### PR DESCRIPTION
For https://redgate.monday.com/boards/3407626507/pulses/6991475342

The layout change has been approved by Sarah Hellowell, I sent a mock-up over by email. 

This notice is currently only on one form (https://www.red-gate.com/hub/events/virtual-devops-july-development) but Mirek would like to roll it out to all forms. 