### PR TITLE
Carousel: Fix bug when carousel slides contain list elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "honeycomb-web-toolkit",
-  "version": "14.3.11",
+  "version": "14.3.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "honeycomb-web-toolkit",
-      "version": "14.3.11",
+      "version": "14.3.16",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.22.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-web-toolkit",
-  "version": "14.3.15",
+  "version": "14.3.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/red-gate/honeycomb-web-toolkit"

--- a/src/carousel/js/honeycomb.carousel.js
+++ b/src/carousel/js/honeycomb.carousel.js
@@ -21,7 +21,7 @@ const rearrangeNav = (carousel) => {
 
         // the left button can't be the first element in the <ul>, otherwise it messes up the navigation, which counts <ul> child elements to map the slides to the links - adding a new first-child pushes the links off by one
         // so we need to add it to the end of the list, and translate its position by working out the width of the nav, plus the width of the arrow
-        let navWidth = ( carousel.querySelectorAll('ul li').length - 1 ) * 30 + 130;
+        let navWidth = ( nav.querySelectorAll('li').length - 1 ) * 30 + 130;
         leftButton.style.transform = `translate(-${navWidth}px, 0px)`;
     
     } else if(!nav && leftButton && rightButton) {

--- a/src/carousel/js/honeycomb.carousel.js
+++ b/src/carousel/js/honeycomb.carousel.js
@@ -1,8 +1,10 @@
 import loadScript from '../../document/js/honeycomb.document.load-script';
 
+const paginationClassName = 'carousel__pagination';
+
 const rearrangeNav = (carousel) => {
     // selectors
-    let nav = carousel.querySelector('ul');
+    let nav = carousel.querySelector(`ul.${paginationClassName}`);
     let leftButton = carousel.querySelector('.slick-prev');
     let rightButton = carousel.querySelector('.slick-next');
 
@@ -67,7 +69,7 @@ const init = ( config = {} ) => {
                 let carousel = carousels[ i ];
                 let options = {
                     autoplaySpeed: 4000,
-                    dotsClass: 'slick-dots carousel__pagination',
+                    dotsClass: `slick-dots ${paginationClassName}`,
                     adaptiveHeight: false,
                     dots: true
                 };


### PR DESCRIPTION
The carousel JS is looking for any lists inside the carousel component, and when list elements are used in a carousel slide it selects those, rather than the pagination list its trying to select.

This PR fixes that issue by providing a class name and element to query on.