### PR TITLE
Remove button styling, fix font size

### DIFF
--- a/src/confluence/css/objects/_honeycomb.confluence.objects.expand.scss
+++ b/src/confluence/css/objects/_honeycomb.confluence.objects.expand.scss
@@ -29,12 +29,8 @@
             @extend .icon--chevron-right;
         }
 
-        button.aui-button-link {
-        background-color: transparent !important;
-
-            &:hover {
-                background-color: transparent !important;
-            }
+        .aui-button {
+            font-size: 16px!important;
         }
     }
 }


### PR DESCRIPTION
Removes previous change (it looks like this was fixed separately but not applied), and changes font size on the header for expanding lists.
