### PR TITLE
Exclude WordPress editor UI buttons from global button styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-web-toolkit",
-  "version": "14.3.36",
+  "version": "14.3.37",
   "repository": {
     "type": "git",
     "url": "https://github.com/red-gate/honeycomb-web-toolkit"

--- a/src/button/css/raw/_honeycomb.button.raw.buttons.scss
+++ b/src/button/css/raw/_honeycomb.button.raw.buttons.scss
@@ -1,4 +1,4 @@
-input[type="submit"], button:not(.aui-button, .rw-btn) {
+input[type="submit"], button:not(.aui-button, .rw-btn, .components-button) {
     @extend %button;
     
     &.button--large {


### PR DESCRIPTION
When a site's stylesheet is loaded into the WordPress page editor, the global button styling also restyles the editor's own buttons. This adds the editor's button class to the exclude list so they keep their normal look – nothing changes on the front end.

First of three: this, then the version bump into the site (red-gate/website-static#5975), then loading the stylesheet into the editor (red-gate/WP-www.red-gate.com#533).