### PR TITLE
Exclude lightbox buttons from default styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-web-toolkit",
-  "version": "14.3.37",
+  "version": "14.3.38",
   "repository": {
     "type": "git",
     "url": "https://github.com/red-gate/honeycomb-web-toolkit"

--- a/src/button/css/raw/_honeycomb.button.raw.buttons.scss
+++ b/src/button/css/raw/_honeycomb.button.raw.buttons.scss
@@ -1,4 +1,4 @@
-input[type="submit"], button:not(.aui-button, .rw-btn, .components-button) {
+input[type="submit"], button:not(.aui-button, .rw-btn, .components-button, .fslightbox-toolbar-button) {
     @extend %button;
     
     &.button--large {


### PR DESCRIPTION
`fslightbox v2` Uses buttons instead of links, so need to exclude them from the default styling.

Needs to merge ahead of https://github.com/red-gate/website-static/pull/6007, which I'll update to include the release tag for this once it's merged.